### PR TITLE
Validate the tag-id byte array as UUID.

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -14,7 +14,7 @@
 # 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.  
 # 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
 
-name: cover ≥76%
+name: cover ≥78%
 on: [push, pull_request]
 jobs:
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.15
 
 require (
 	github.com/fxamacker/cbor/v2 v2.3.0
+	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.3.0 h1:aM45YGMctNakddNNAezPxDUpv38j44Abh+hifNuqXik=
 github.com/fxamacker/cbor/v2 v2.3.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/tagid.go
+++ b/tagid.go
@@ -19,6 +19,8 @@ type TagID struct {
 	val interface{}
 }
 
+// NewTagID takes a UUID (either as in string form or byte array) or an untyped
+// string and returns a TagID
 func NewTagID(v interface{}) *TagID {
 	switch t := v.(type) {
 	case string:
@@ -44,6 +46,7 @@ func string2TagID(s string) (*TagID, error) {
 	return nil, errors.New("tag-id is neither a UUID nor a valid string")
 }
 
+// NewTagIDFromString takes an untyped string and returns a TagID
 func NewTagIDFromString(s string) (*TagID, error) {
 	if s == "" {
 		return nil, errors.New("empty string")
@@ -51,6 +54,7 @@ func NewTagIDFromString(s string) (*TagID, error) {
 	return &TagID{s}, nil
 }
 
+// NewTagIDFromUUIDString takes an UUID in string form and returns a TagID
 func NewTagIDFromUUIDString(s string) (*TagID, error) {
 	u, err := uuid.Parse(s)
 	if err != nil {
@@ -60,6 +64,7 @@ func NewTagIDFromUUIDString(s string) (*TagID, error) {
 	return &TagID{u}, nil
 }
 
+// NewTagIDFromUUIDBytes takes an UUID as byte array and returns a TagID
 func NewTagIDFromUUIDBytes(b []byte) (*TagID, error) {
 	u, err := uuid.FromBytes(b)
 	if err != nil {

--- a/tagid_test.go
+++ b/tagid_test.go
@@ -8,7 +8,27 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestTagID_NewFromUUIDString(t *testing.T) {
+	tv := "00010001-0001-0001-0001-000100010001"
+
+	expected := "00010001-0001-0001-0001-000100010001"
+
+	actual := NewTagID(tv)
+
+	assert.NotNil(t, actual)
+	assert.Equal(t, expected, actual.String())
+}
+
+func TestTagID_NewTagID_empty(t *testing.T) {
+	tv := ""
+
+	actual := NewTagID(tv)
+
+	assert.Nil(t, actual)
+}
 
 func TestTagID_16Bytes(t *testing.T) {
 	tv := []byte{
@@ -16,7 +36,7 @@ func TestTagID_16Bytes(t *testing.T) {
 		0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01,
 	}
 
-	expected := "00010001000100010001000100010001"
+	expected := "00010001-0001-0001-0001-000100010001"
 
 	actual := NewTagID(tv)
 
@@ -30,9 +50,9 @@ func TestTagID_15Bytes(t *testing.T) {
 		0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00,
 	}
 
-	err := checkTagID(tv)
+	_, err := NewTagIDFromUUIDBytes(tv)
 
-	assert.EqualError(t, err, "binary tag-id MUST be 16 bytes")
+	assert.EqualError(t, err, "invalid UUID (got 15 bytes)")
 }
 
 func TestTagID_17Bytes(t *testing.T) {
@@ -42,9 +62,9 @@ func TestTagID_17Bytes(t *testing.T) {
 		0x00,
 	}
 
-	err := checkTagID(tv)
+	_, err := NewTagIDFromUUIDBytes(tv)
 
-	assert.EqualError(t, err, "binary tag-id MUST be 16 bytes")
+	assert.EqualError(t, err, "invalid UUID (got 17 bytes)")
 }
 
 func TestTagID_String(t *testing.T) {
@@ -65,9 +85,26 @@ func TestTagID_UnhandledType(t *testing.T) {
 		b: "one",
 	}
 
-	err := checkTagID(tv)
+	actual := NewTagID(tv)
 
-	assert.EqualError(t, err, "tag-id MUST be []byte or string; got struct { a int; b string }")
+	assert.Nil(t, actual)
+}
+
+func TestTagID_UnmarshalXMLAttrString_empty(t *testing.T) {
+	v := ""
+
+	tv := xml.Attr{
+		Name:  xml.Name{Local: "tagId"},
+		Value: v,
+	}
+
+	expectedErr := `error unmarshaling tag-id "": tag-id is neither a UUID nor a valid string`
+
+	var actual TagID
+
+	err := actual.UnmarshalXMLAttr(tv)
+
+	assert.EqualError(t, err, expectedErr)
 }
 
 func TestTagID_UnmarshalXMLAttrString(t *testing.T) {
@@ -78,20 +115,22 @@ func TestTagID_UnmarshalXMLAttrString(t *testing.T) {
 		Value: v,
 	}
 
-	expected := *NewTagID(v)
+	expected := NewTagID(v)
+	require.NotNil(t, expected)
 
 	var actual TagID
 
 	err := actual.UnmarshalXMLAttr(tv)
 
 	assert.Nil(t, err)
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, *expected, actual)
 }
 
 func TestTagID_MarshalXMLAttrString(t *testing.T) {
 	v := "example.acme.roadrunner-sw-v1-0-0"
 
-	tv := *NewTagID(v)
+	tv := NewTagID(v)
+	require.NotNil(t, tv)
 
 	expected := xml.Attr{
 		Name:  xml.Name{Local: "tagId"},
@@ -110,11 +149,15 @@ func TestTagID_MarshalXMLAttrBytes(t *testing.T) {
 		0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01,
 	}
 
-	tv := *NewTagID(v)
+	tv := NewTagID(v)
+	require.NotNil(t, tv)
 
-	_, err := tv.MarshalXMLAttr(xml.Name{Local: "tagId"})
+	expected := "00010001-0001-0001-0001-000100010001"
 
-	assert.EqualError(t, err, "only tag-id of type string can be serialized to XML")
+	actual, err := tv.MarshalXMLAttr(xml.Name{Local: "tagId"})
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual.Value)
 }
 
 func TestTagID_MarshalJSONBytes(t *testing.T) {
@@ -123,19 +166,73 @@ func TestTagID_MarshalJSONBytes(t *testing.T) {
 		0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01,
 	}
 
-	tv := *NewTagID(v)
+	tv := NewTagID(v)
+	require.NotNil(t, tv)
 
-	_, err := tv.MarshalJSON()
+	expected := `"00010001-0001-0001-0001-000100010001"`
 
-	assert.EqualError(t, err, "only tag-id of type string can be serialized to JSON")
+	actual, err := tv.MarshalJSON()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, string(actual))
 }
 
-func TestTagID_UnMarshalJSONUnhandled(t *testing.T) {
+func TestTagID_UnmarshalJSONUnhandled(t *testing.T) {
 	tv := []byte(`{ "k": "0" }`)
+
+	var actual TagID
+
+	expectedErr := "error unmarshaling tag-id: json: cannot unmarshal object into Go value of type string"
+
+	err := actual.UnmarshalJSON(tv)
+
+	assert.EqualError(t, err, expectedErr)
+}
+
+func TestTagID_UnmarshalJSON_empty(t *testing.T) {
+	tv := []byte(`""`)
+
+	expectedErr := `error unmarshaling tag-id "": tag-id is neither a UUID nor a valid string`
 
 	var actual TagID
 
 	err := actual.UnmarshalJSON(tv)
 
-	assert.EqualError(t, err, "expecting string, found map[string]interface {} instead")
+	assert.EqualError(t, err, expectedErr)
+}
+
+func TestTagID_UnmarshalCBOR_EOF(t *testing.T) {
+	tv := []byte{}
+
+	expectedErr := `EOF`
+
+	var actual TagID
+
+	err := actual.UnmarshalCBOR(tv)
+
+	assert.EqualError(t, err, expectedErr)
+}
+
+func TestTagID_UnmarshalCBOR_unhandled_type(t *testing.T) {
+	tv := []byte{0xf6} // null
+
+	expectedErr := `error unmarshaling tag-id: tag-id MUST be []byte or string; got <nil>`
+
+	var actual TagID
+
+	err := actual.UnmarshalCBOR(tv)
+
+	assert.EqualError(t, err, expectedErr)
+}
+
+func TestTagID_UnmarshalCBOR_empty_bytes(t *testing.T) {
+	tv := []byte{0x40} // bytes(0)
+
+	expectedErr := `error unmarshaling tag-id: invalid UUID (got 0 bytes)`
+
+	var actual TagID
+
+	err := actual.UnmarshalCBOR(tv)
+
+	assert.EqualError(t, err, expectedErr)
 }


### PR DESCRIPTION
Validate the tag-id byte array as UUID.  Besides, given that the type of
the byte array is well defined and it has a known string representation,
allow it in XML and JSON serialisations.

Also, increase test coverage (partially addressing #12)

Fixes #18