### PR TITLE
Add uuid.UUID as base for NewTagID()

### DIFF
--- a/tagid.go
+++ b/tagid.go
@@ -19,7 +19,7 @@ type TagID struct {
 	val interface{}
 }
 
-// NewTagID takes a UUID (either as in string form or byte array) or an untyped
+// NewTagID takes a UUID (either as in string form, byte array or google.uuid.UUID) or an untyped
 // string and returns a TagID
 func NewTagID(v interface{}) *TagID {
 	switch t := v.(type) {
@@ -29,6 +29,8 @@ func NewTagID(v interface{}) *TagID {
 	case []byte:
 		tagID, _ := NewTagIDFromUUIDBytes(t)
 		return tagID
+	case uuid.UUID:
+		return &TagID{v}
 	default:
 		return nil
 	}

--- a/tagid.go
+++ b/tagid.go
@@ -19,8 +19,8 @@ type TagID struct {
 	val interface{}
 }
 
-// NewTagID takes a UUID (either as in string form, byte array or google.uuid.UUID) or an untyped
-// string and returns a TagID
+// NewTagID takes a UUID as either a string, byte array or google.uuid.UUID
+// and returns a TagID
 func NewTagID(v interface{}) *TagID {
 	switch t := v.(type) {
 	case string:


### PR DESCRIPTION
I stumbled upon it, while trying to generate a uuid and assign to SoftwareIdentity.TagID.
Now I can easily write for example:
```go
var id swid.SoftwareIdentity
id.TagID = *swid.NewTagID(uuid.NewSHA1(uuid.NameSpaceDNS, "test"))
```
otherwise it get's complicated, since I can't access TagID's variable and there are no setter/getter like functions to get around it.