### PR TITLE
Update CI lint

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install golangci-lint 
       run: |
         go version
-        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
     - name: Run required linters in .golangci.yml plus hard-coded ones here
       run: $(go env GOPATH)/bin/golangci-lint run --timeout=3m
     - name: Run optional linters (not required to pass)


### PR DESCRIPTION
* update download host from goreleaser.com to GitHub (gorealeaser.com does not resolve anymore)
* bump version from 1.23.8 to latest (1.46.2)