### PR TITLE
Add Type Name to error message in CBOR conversion

### DIFF
--- a/common.go
+++ b/common.go
@@ -154,7 +154,7 @@ func arrayToCBOR(a reflect.Value) ([]byte, error) {
 
 	switch a.Len() {
 	case 0:
-		return nil, errors.New("array MUST NOT be 0-length")
+		return nil, fmt.Errorf("array of %s MUST NOT be 0-length", a.Type().Name())
 	case 1:
 		return em.Marshal(a.Index(0).Interface())
 	default:

--- a/files_test.go
+++ b/files_test.go
@@ -15,7 +15,7 @@ func TestFiles_DoNotEncodeZeroLength(t *testing.T) {
 	tv := Files{}
 
 	_, err := em.Marshal(tv)
-	assert.EqualError(t, err, "array MUST NOT be 0-length")
+	assert.EqualError(t, err, "array of Files MUST NOT be 0-length")
 }
 
 func TestFiles_RoundtripEncodeOne(t *testing.T) {

--- a/processes_test.go
+++ b/processes_test.go
@@ -22,7 +22,7 @@ func TestProcesses_MarshalCBOR(t *testing.T) {
 			name:        "zero elements",
 			tv:          Processes{},
 			expected:    []byte("__ignored__"),
-			expectedErr: errors.New("array MUST NOT be 0-length"),
+			expectedErr: errors.New("array of Processes MUST NOT be 0-length"),
 		},
 		{
 			name: "one element (encodes to scalar)",


### PR DESCRIPTION
It was first a bit puzzling, when I got the error message. I think adding the problematic type greatly enhances finding the cause of ones problem.